### PR TITLE
Fix `Dockerfile` build warnings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,31 @@
+---
+name: Test Secrets Manager Resource Image Build
+
+on:
+  push:
+    tags-ignore:
+    - '**'
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  image-build-test:
+    if: ${{ github.repository == 'homeport/secrets-manager-resource' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    env:
+      IMAGE_HOST: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build container image
+      env:
+        DOCKER_BUILDKIT: "1"
+        BUILDKIT_PROGRESS: plain
+      run: docker build --tag "${IMAGE_HOST}/${IMAGE_NAME}:test" .

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-FROM golang:1.24.4 as bootstrap
+FROM golang:1.24.4 AS bootstrap
 WORKDIR /go/src/github.com/homeport/secrets-manager-resource
 COPY . .
 
-ENV CGO_ENABLED 0
-ENV GOOS linux
-ENV GOARCH amd64
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
 RUN --mount=type=cache,target=/root/.cache/go-build \
     mkdir -p /tmp/dist/opt/resource && \
     go build \


### PR DESCRIPTION
Fix `Dockerfile` build warnings by using correct `ENV` syntax and case.
