### PR TITLE
Change search to be exact name match

### DIFF
--- a/internal/smr/secrets.go
+++ b/internal/smr/secrets.go
@@ -75,7 +75,35 @@ func GetSecretMetaDataBySecretName(service sm.SecretsManagerV2, source Source) (
 			return nil, err
 		}
 
-		results = append(results, nextPage...)
+		for _, entry := range nextPage {
+			var name string
+			switch secretMetadata := entry.(type) {
+			case *sm.ImportedCertificateMetadata:
+				name = *secretMetadata.Name
+
+			case *sm.PublicCertificateMetadata:
+				name = *secretMetadata.Name
+
+			case *sm.KVSecretMetadata:
+				name = *secretMetadata.Name
+
+			case *sm.UsernamePasswordSecretMetadata:
+				name = *secretMetadata.Name
+
+			case *sm.IAMCredentialsSecretMetadata:
+				name = *secretMetadata.Name
+
+			case *sm.ArbitrarySecretMetadata:
+				name = *secretMetadata.Name
+
+			case *sm.PrivateCertificateMetadata:
+				name = *secretMetadata.Name
+			}
+
+			if name == source.SecretName {
+				results = append(results, entry)
+			}
+		}
 	}
 
 	if len(results) == 0 {


### PR DESCRIPTION
By default, the search string used for the Secrets Manager API is
searching a substring match, which is not ideal in most use cases.

Change look-up code to ensure that search is an exact name match.
